### PR TITLE
Add support for polymorphism using System.Text.Json attributes

### DIFF
--- a/src/AspNet.FluentValidation/ValidationExtensions.cs
+++ b/src/AspNet.FluentValidation/ValidationExtensions.cs
@@ -119,8 +119,7 @@ public static class ValidationExtensions
                 };
 
                 // If the ValidationStrategy delegate changes to return the validateable types
-                // then support for System.Text.Json polymorphic deserialization then
-                // this could just be made into a strategy
+                // support for System.Text.Json polymorphic deserialization could then be made into a strategy
                 if (IsPolymorphicType(parameter.ParameterType, out Type[] derivedTypes))
                 {
                     // Create the validator types upfront for each derived type

--- a/src/AspNet.FluentValidation/ValidationExtensions.cs
+++ b/src/AspNet.FluentValidation/ValidationExtensions.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using FluentValidation;
 using Microsoft.AspNetCore.Http;
 using O9d.AspNet.FluentValidation;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.Builder;
 
@@ -62,9 +63,19 @@ public static class ValidationExtensions
         {
             var argument = invocationContext.Arguments[descriptor.ArgumentIndex];
 
+            Type validatorType = descriptor.ValidatorType;
+
+            // If a type map is provided then attempt to resolve a validator using the runtime type
+            if (descriptor.UseRuntimeType
+                && argument?.GetType() is Type runtimeType
+                && descriptor.TypeMap!.TryGetValue(runtimeType, out Type? runtimeValidatorType))
+            {
+                validatorType = runtimeValidatorType;
+            }
+
             // Resolve the validator
             IValidator? validator
-                = invocationContext.HttpContext.RequestServices.GetService(descriptor.ValidatorType) as IValidator;
+                = invocationContext.HttpContext.RequestServices.GetService(validatorType) as IValidator;
 
             // TODO consider whether we mutate the descriptor to skip if no validator is registered
 
@@ -91,22 +102,43 @@ public static class ValidationExtensions
     {
         ParameterInfo[] parameters = methodInfo.GetParameters();
 
+        static Type CreateValidatorType(Type parameterType)
+            => typeof(IValidator<>).MakeGenericType(parameterType);
+
         for (int i = 0; i < parameters.Length; i++)
         {
             ParameterInfo parameter = parameters[i];
 
             if (options.ShouldValidate(parameter, metadata))
             {
-                Type validatorType = typeof(IValidator<>).MakeGenericType(parameter.ParameterType);
-
-                yield return new ValidateableParameterDescriptor
+                var descriptor = new ValidateableParameterDescriptor
                 {
                     ArgumentIndex = i,
                     ArgumentType = parameter.ParameterType,
-                    ValidatorType = validatorType
+                    ValidatorType = CreateValidatorType(parameter.ParameterType)
                 };
+
+                // If the ValidationStrategy delegate changes to return the validateable types
+                // then support for System.Text.Json polymorphic deserialization then
+                // this could just be made into a strategy
+                if (IsPolymorphicType(parameter.ParameterType, out Type[] derivedTypes))
+                {
+                    // Create the validator types upfront for each derived type
+                    descriptor.TypeMap = derivedTypes.ToDictionary(t => t, t => CreateValidatorType(t));
+                }
+
+                yield return descriptor;
             }
         }
+    }
+
+    private static bool IsPolymorphicType(Type parameterType, out Type[] derivedTypes)
+    {
+        derivedTypes = parameterType.GetCustomAttributes<JsonDerivedTypeAttribute>()
+            .Select(attr => attr.DerivedType)
+            .ToArray();
+
+        return derivedTypes.Length > 0;
     }
 
     private class ValidateableParameterDescriptor
@@ -114,5 +146,8 @@ public static class ValidationExtensions
         public required int ArgumentIndex { get; init; }
         public required Type ArgumentType { get; init; }
         public required Type ValidatorType { get; init; }
+        public Dictionary<Type, Type>? TypeMap { get; set; }
+
+        public bool UseRuntimeType => TypeMap?.Count > 0;
     }
 }


### PR DESCRIPTION
This PR is in response to [this conversation](https://twitter.com/davidfowl/status/1606060489351614467?s=20&t=BgiVaTJqy23S349buf9asg) with @davidfowl regarding support for polymorphism.

With the current implementation, the parameter and corresponding validator types are defined at startup. If a derived type is provided at runtime, a validator will not be resolved.

The more likely use case for this (and one that we use frequently in our APIs) is where we need to deserialize to the appropriate type using a type discriminator in the request, for example:

```json
{
   "type":"student",
   "name":"J Doe",
   "studentId":"123abc"
}
```

As of .NET 7.0, System.Text.Json includes [support for polymorphic types](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/polymorphism?pivots=dotnet-7-0) which is applied using attributes, for example:

```c#
    [JsonPolymorphic(TypeDiscriminatorPropertyName = "type", UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType)]
    [JsonDerivedType(typeof(Student), "student")]
    public class Person
    {
        public string? Name { get; set; }
    }

    public class Student : Person
    {
        public string? StudentId { get; set; }
    }
```

This PR adds support for these attributes. When a type is decorated with one or more `[JsonDerivedType]` attributes, we generate a type map containing the derived type and the validator type. This is preferable to generating the validator type by reflection on each request. 

When validating, if the type map is populated we resolve the derived validator based on the runtime type, otherwise we fall back to the default behaviour based on the parameter info. The main goal is to avoid incurring any runtime cost for non-polymorphic use cases.

Of course this doesn't support every use case (including the example in the conversation linked above) but I would prefer to let feedback drive this.

If the library _was_ to support polymorphism by other means (e.g. BindAsync) then I believe we would need to change the existing validateable delegate to return a type map rather than a boolean value. Then the corresponding strategies could be updated to support passing derived types as parameters (I'm in favour of them being specified explicitly) e.g:

```c#
group.MapPost("/things", ([Validate(derivedTypes: typeof(Student), typeof(Teacher)] DoSomething _) => Results.Ok());
```
 
