### PR TITLE
Added ParameterInfo argument to InvalidResultFactory

### DIFF
--- a/src/AspNet.FluentValidation/ValidationExtensions.cs
+++ b/src/AspNet.FluentValidation/ValidationExtensions.cs
@@ -76,7 +76,7 @@ public static class ValidationExtensions
 
                 if (!validationResult.IsValid)
                 {
-                    return options.InvalidResultFactory(validationResult);
+                    return options.InvalidResultFactory(validationResult, descriptor.Parameter);
                 }
             }
         }
@@ -103,7 +103,8 @@ public static class ValidationExtensions
                 {
                     ArgumentIndex = i,
                     ArgumentType = parameter.ParameterType,
-                    ValidatorType = validatorType
+                    ValidatorType = validatorType,
+                    Parameter = parameter
                 };
             }
         }
@@ -114,5 +115,6 @@ public static class ValidationExtensions
         public required int ArgumentIndex { get; init; }
         public required Type ArgumentType { get; init; }
         public required Type ValidatorType { get; init; }
+        public required ParameterInfo Parameter { get; init; }
     }
 }

--- a/src/AspNet.FluentValidation/ValidationExtensions.cs
+++ b/src/AspNet.FluentValidation/ValidationExtensions.cs
@@ -74,6 +74,8 @@ public static class ValidationExtensions
                     new ValidationContext<object>(argument)
                 );
 
+				options.ProcessBindingValidations?.Invoke( invocationContext, descriptor.Parameter, validationResult );
+
                 if (!validationResult.IsValid)
                 {
                     return options.InvalidResultFactory(validationResult, descriptor.Parameter);

--- a/src/AspNet.FluentValidation/ValidationFilterOptions.cs
+++ b/src/AspNet.FluentValidation/ValidationFilterOptions.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Reflection;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
 
@@ -17,8 +18,8 @@ public sealed class ValidationFilterOptions
     /// <summary>
     /// Gets or sets the factory used to create a HTTP result when validation fails. Defaults to a HTTP 422 Validation Problem.
     /// </summary>
-    public Func<ValidationResult, IResult> InvalidResultFactory { get; set; } = CreateValidationProblemResult;
+    public Func<ValidationResult, ParameterInfo, IResult> InvalidResultFactory { get; set; } = CreateValidationProblemResult;
 
-    private static IResult CreateValidationProblemResult(ValidationResult validationResult)
+    private static IResult CreateValidationProblemResult(ValidationResult validationResult, ParameterInfo parameter)
         => Results.ValidationProblem(validationResult.ToDictionary(), statusCode: (int)HttpStatusCode.UnprocessableEntity);
 }

--- a/src/AspNet.FluentValidation/ValidationFilterOptions.cs
+++ b/src/AspNet.FluentValidation/ValidationFilterOptions.cs
@@ -22,4 +22,10 @@ public sealed class ValidationFilterOptions
 
     private static IResult CreateValidationProblemResult(ValidationResult validationResult, ParameterInfo parameter)
         => Results.ValidationProblem(validationResult.ToDictionary(), statusCode: (int)HttpStatusCode.UnprocessableEntity);
+
+    /// <summary>
+    /// Gets or sets the handler used to process any additional 'model binding' validation.  If any binding validation meta data
+	/// was generated, their error responses can be added to the ValidationResult.
+    /// </summary>
+	public Action<EndpointFilterInvocationContext, ParameterInfo, ValidationResult>? ProcessBindingValidations { get; set; }
 }

--- a/test/AspNet.FluentValidation.Tests/ValidationFilterTests.cs
+++ b/test/AspNet.FluentValidation.Tests/ValidationFilterTests.cs
@@ -130,7 +130,7 @@ public class ValidationFilterTests
             app =>
             {
                 var group = app.MapGroup("/")
-                    .WithValidationFilter(options => options.InvalidResultFactory = _ => Results.BadRequest());
+                    .WithValidationFilter(options => options.InvalidResultFactory = ( _, _ ) => Results.BadRequest());
 
                 group.MapPost("/things", ([Validate] DoSomething _) => Results.Ok());
             },


### PR DESCRIPTION
Maybe too niche, but only thing missing for me was ability to grab some custom attributes on the parameter being validated during the creation of the validation response.

This pull request simply added a `ParameterInfo Parameter` property to the `ValidateableParameterDescriptor`, and then inside `CreateValidationFilter` when calling `InvalidResultFactory` passed it in...

```
var validationResult = await validator.ValidateAsync(
    new ValidationContext<object>(argument)
);

if (!validationResult.IsValid)
{
    return options.InvalidResultFactory(validationResult, descriptor.Parameter);
}
```